### PR TITLE
Style form

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -104,18 +104,18 @@ a {
 }
 
 .store-wrapper {
-	display: grid;
+  display: grid;
   grid-gap: 75px;
-	grid-template-columns: repeat(auto-fill, minmax(250px, 1fr) ) ;
-	color: #444;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr) ) ;
+  color: #444;
   margin: 3% 10% 0 10%;
 }
 
 .store-box {
-	color: #fff;
-	border-radius: 5px;
-	padding: 20px;
-	font-size: 150%;
+  color: #fff;
+  border-radius: 5px;
+  padding: 20px;
+  font-size: 150%;
   margin-bottom: 10%;
   height: 400px;
 }
@@ -186,7 +186,7 @@ a {
       .float-label-control textarea:focus { padding-bottom: 4px; }
   .float-label-control input, .float-label-control textarea { display: block; width: 100%; padding: 0.1em 0em 1px 0em; border: none; border-radius: 0px; border-bottom: 1px solid $font-color; outline: none; margin: 0px; background: none; }
   .float-label-control textarea { padding: 0.1em 0em 5px 0em; }
-  .float-label-control label { position: absolute; font-weight: normal; top: -1.0em; left: 0.08em; color: $font-color; z-index: -1; font-size: 0.85em; -moz-animation: float-labels 300ms none ease-out; -webkit-animation: float-labels 300ms none ease-out; -o-animation: float-labels 300ms none ease-out; -ms-animation: float-labels 300ms none ease-out; -khtml-animation: float-labels 300ms none ease-out; animation: float-labels 300ms none ease-out; /* There is a bug sometimes pausing the animation. This avoids that.*/ animation-play-state: running !important; -webkit-animation-play-state: running !important; }
+  .float-label-control label { font-weight: normal; top: -1.0em; left: 0.08em; color: $font-color; z-index: -1; font-size: 0.85em; -moz-animation: float-labels 300ms none ease-out; -webkit-animation: float-labels 300ms none ease-out; -o-animation: float-labels 300ms none ease-out; -ms-animation: float-labels 300ms none ease-out; -khtml-animation: float-labels 300ms none ease-out; animation: float-labels 300ms none ease-out; /* There is a bug sometimes pausing the animation. This avoids that.*/ animation-play-state: running !important; -webkit-animation-play-state: running !important; }
   .float-label-control input.empty + label,
   .float-label-control textarea.empty + label { top: 0.1em; font-size: 1.5em; animation: none; -webkit-animation: none; }
   .float-label-control input:not(.empty) + label,

--- a/spec/features/admin/authentication/admin_can_update_their_account_but_not_user_account_spec.rb
+++ b/spec/features/admin/authentication/admin_can_update_their_account_but_not_user_account_spec.rb
@@ -36,7 +36,7 @@ describe "As a logged in Admin" do
   it "returns a welcome message for admins" do
     allow_any_instance_of(ApplicationController).to receive(:current_user). and_return(admin)
     visit admin_dashboard_index_path
-    expect(page).to have_content("You're logged in as an Administrator")
+    expect(page).to have_content("Admin Dashboard")
   end
 
   it "returns a 404 when a non-admin visits the admin dashboard" do

--- a/spec/features/admin/authentication/admin_can_visit_dashboard_spec.rb
+++ b/spec/features/admin/authentication/admin_can_visit_dashboard_spec.rb
@@ -54,7 +54,7 @@ feature "as an Admin" do
         click_on("Login")
       end
 
-      expect(page).to have_content("You're logged in as an Administrator.")
+      expect(page).to have_content("Admin Dashboard")
 
       expect(current_path).to eq(admin_dashboard_index_path)
     end


### PR DESCRIPTION
### Description of changes:
#### Any background context you want to provide?
#### What does  this PR do?
Form styling gets rid of previous overlap and fixes admin tests that were broken after admin flash removed
#### What are the relevant story numbers?
none
#### Screenshots (if appropriate)
<img width="1031" alt="screen shot 2018-02-14 at 5 21 08 pm" src="https://user-images.githubusercontent.com/23040094/36235061-ac7002b2-11ab-11e8-9b62-024bf356da41.png">
<img width="1322" alt="screen shot 2018-02-14 at 5 20 55 pm" src="https://user-images.githubusercontent.com/23040094/36235062-ac7f221a-11ab-11e8-9cbf-8d9fafbafee6.png">

### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](put .gif link here - can be found under "advanced" on giphy)

### For the reviewer:
#### How should this be manually tested?
Look at forms and run rspec
#### Questions:
  - Do Migrations Need to be ran?
no
  - Do Environment Variables need to be set?
no
  - Any other deploy steps?
#### Other Notes:

### Tags: @anlewis @tylermarshal @katyjane8 @timomitchel