### PR TITLE
allow store admin to manage user roles (store_manager and store_admin)

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,13 @@
+class Admin::UsersController < ApplicationController
+  def add_role
+    user = User.find(params[:id])
+    role = Role.find_or_create_by(title: params[:role])
+    user.roles << role
+    redirect_back(fallback_location: admin_dashboard_index_path)
+  end
+
+  def remove_role
+    user = User.find(params[:id])
+    user.roles.find_by(title: params[:role]).destroy
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,9 @@
 class UsersController < ApplicationController
 
+  def index
+    @users = User.all
+  end
+
   def new
     @user = User.new
   end
@@ -42,11 +46,10 @@ class UsersController < ApplicationController
     end
   end
 
-
   private
 
-  def user_params
-    params.require(:user).permit(:first_name, :last_name, :email, :password, :address)
-  end
+    def user_params
+      params.require(:user).permit(:first_name, :last_name, :email, :password, :address)
+    end
 
 end

--- a/app/services/permission.rb
+++ b/app/services/permission.rb
@@ -22,6 +22,8 @@ class Permission
       return true if controller == "categories" && action == "show"
     elsif user.store_admin?
       return true if controller == "admin/stores/items" && action.in?(["index", "new", "create", "edit", "update"])
+      return true if controller == "admin/users" && action == "add_role"
+      return true if controller == "admin/users" && action == "remove_role"
       return true if controller == "categories" && action == "show"
       return true if controller == "carts" && action.in?(["index", "destroy", "update", "create"])
       return true if controller == "users" && action.in?(["index", "show", "edit", "update", "new", "create"])

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -6,9 +6,9 @@
     <a class="nav-item nav-link active" id="nav-home-tab" data-toggle="tab" href="#nav-home" role="tab" aria-controls="nav-home" aria-expanded="true">View Orders</a>
     <%= link_to "Update Account", edit_user_path(current_user), class: "nav-item nav-link" %>
     <%= link_to "View Analytics", admin_analytics_path, class: "nav-item nav-link" %>
-
-    </div>
+    <%= link_to "View Users", users_path, class: "nav-item nav-link" %>
   </nav>
+</div>
   <div class="container margin-top-5">
   <div class="tab-content" id="nav-tabContent">
     <div class="tab-pane fade show active" id="nav-home" role="tabpanel" aria-labelledby="nav-home-tab">

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,0 +1,44 @@
+
+<table class="table table-hover">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Roles</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @users.each do |user| %>
+      <tr class="user-<%= user.id %>">
+        <td><%= user.first_name %> <%= user.last_name %></td>
+        <td>
+          <ul>
+            <% user.roles.each do |role| %>
+              <li><%= role.title %></li>
+            <% end %>
+          </ul>
+        </td>
+        <% if user.store_manager? && user.store_admin? %>
+          <td class="both-exist">
+            <%= link_to "Remove Store Manager Role", admin_remove_role_path(user, role: "store_manager"), method: :put, class: "badge badge-success" %>
+            <%= link_to "Remove Store Admin Role", admin_remove_role_path(user, role: "store_admin"), method: :put, class: "badge badge-success" %>
+          </td>
+        <% elsif user.store_manager? %>
+          <td class="manager-only">
+            <%= link_to "Remove Store Manager Role", admin_remove_role_path(user, role: "store_manager"), method: :put, class: "badge badge-success" %>
+            <%= link_to "Make Store Admin", admin_add_role_path(user, role: "store_admin"), method: :put, class: "badge badge-success" %>
+          </td>
+        <% elsif user.store_admin? %>
+          <td class="admin-only">
+            <%= link_to "Remove Store Admin Role", admin_remove_role_path(user, role: "store_admin"), method: :put, class: "badge badge-success" %>
+            <%= link_to "Make Store Manager", admin_add_role_path(user, role: "store_manager"), method: :put, class: "badge badge-success" %>
+          </td>
+        <% else %>
+          <td class="neither-exist">
+            <%= link_to "Make Store Manager", admin_add_role_path(user, role: "store_manager"), method: :put, class: "badge badge-success" %>
+            <%= link_to "Make Store Admin", admin_add_role_path(user, role: "store_admin"), method: :put, class: "badge badge-success" %>
+          </td>
+        <% end %>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,8 @@ Rails.application.routes.draw do
     namespace :stores, as: :store, path: ':store' do
       resources :items, only: [:index, :new, :create, :edit, :update]
     end
+    put '/add_role/:id', :to => 'users#add_role', as: 'add_role'
+    put '/remove_role/:id', :to => 'users#remove_role', as: 'remove_role'
   end
 
   namespace :stores, as: :store, path: ':store' do
@@ -27,7 +29,7 @@ Rails.application.routes.draw do
 
   resources :stores, only: [:index, :show]
 
-  resources :users, only: [:new, :create, :edit, :update]
+  resources :users, only: [:index, :new, :create, :edit, :update]
 
   resources :orders, only: [:index, :new, :show, :update]
 

--- a/spec/features/store_admin/user/store_admin_can_manage_managers_and_store_admins_spec.rb
+++ b/spec/features/store_admin/user/store_admin_can_manage_managers_and_store_admins_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+feature 'Store admin can manage other store managers and store admins for your store' do
+
+  let!(:store_admin) {create(:user)}
+  let!(:store)       {create(:store)}
+  let!(:sa_role)     {create(:role, title: "store_admin")}
+
+  before(:each) do
+    store_admin.roles << sa_role
+    store_admin.stores << store
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(store_admin)
+  end
+
+
+  context "as a valid store admin" do
+    context "they can manage a store manager" do
+      scenario "by making a user a store manager" do
+        user = create(:user)
+
+        expect(user.store_manager?).to be false
+
+        visit admin_dashboard_index_path
+        click_on "View Users"
+        within(".user-#{user.id}") do
+          click_on "Make Store Manager"
+        end
+        user.reload
+
+        expect(user.store_manager?).to be true
+      end
+      scenario "by removing the store manager role from a user" do
+        store_manager = create(:user)
+        manager_role = create(:role, title: "store_manager")
+        store_manager.roles << manager_role
+
+        expect(store_manager.store_manager?).to be true
+
+        visit admin_dashboard_index_path
+        click_on "View Users"
+        within(".user-#{store_manager.id}") do
+         click_on "Remove Store Manager Role"
+        end
+        store_manager.reload
+
+        expect(store_manager.store_manager?).to be false
+      end
+    end
+    context "they can manage a store admin" do
+      scenario "by making user a store admin" do
+        user = create(:user)
+
+        expect(user.store_admin?).to eq false
+
+        visit admin_dashboard_index_path
+        click_on "View Users"
+        within(".user-#{user.id}") do
+          click_on "Make Store Admin"
+        end
+        user.reload
+
+        expect(user.store_admin?).to be true
+      end
+      scenario "by removing the store admin role from a user" do
+        store_admin = create(:user)
+        admin_role = create(:role, title: "store_admin")
+        store_admin.roles << admin_role
+        expect(store_admin.store_admin?).to be true
+
+        visit admin_dashboard_index_path
+        click_on "View Users"
+        within(".user-#{store_admin.id}") do
+          click_on "Remove Store Admin Role"
+        end
+        store_admin.reload
+
+        expect(store_admin.store_admin?).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description of changes:
#### Any background context you want to provide?
#### What does  this PR do?
Allows a store admin to change a user's role with regards to store_admin or store_manager
#### What are the relevant story numbers?
154944912

### For the reviewer:
#### How should this be manually tested?
Login as a store admin, visit admin/dashboard, click on users and change some of the user's roles

#### Questions:
  - Do Migrations Need to be ran?
No
  - Do Environment Variables need to be set?
No
  - Any other deploy steps?
No

### Tags: @anlewis @tylermarshal @katyjane8 @timomitchel